### PR TITLE
add a 'gradlew :python:thin_wheel' task that will build 'python/pjrm-1.11.0-py3-none-any.whl'

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -36,4 +36,4 @@ jobs:
         # See https://github.com/actions/upload-artifact#readme
         with:
           name: wheel
-          path: ./python/*.whl
+          path: ./python/pjrmi*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -26,13 +26,13 @@ jobs:
 
       - name: build thin wheel
         # This will build a single python-only wheel. In order to build a wheel
-        # including the c-extension, rework this job to use cibuildwheel on all
+        # including the C-extension, rework this job to use cibuildwheel on all
         # the desired runners (the `runs-on` line above)
         # https://cibuildwheel.readthedocs.io/en/stable/
         run: |
           ./gradlew :python:thin_wheel
     
-      - uses: actions/upload-artifact@3
+      - uses: actions/upload-artifact@v3
         with:
           name: wheel
           path: ./python/*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: build thin wheel
+        # This will build a single python-only wheel. In order to build a wheel
+        # including the c-extension, rework this job to use cibuildwheel on all
+        # the desired runners (the `runs-on` line above)
+        # https://cibuildwheel.readthedocs.io/en/stable/
         run: |
           ./gradlew :python:thin_wheel
     

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,6 +1,3 @@
-# This is a basic workflow to help you get started with Actions.
-# To be filled in as part of https://github.com/deshaw/pjrmi/pull/1
-
 name: Wheels
 
 # Controls when the workflow will run
@@ -18,8 +15,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  # This workflow contains a single job called "build"
-  build_wheel:
+  build_thin_wheel:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -33,6 +33,7 @@ jobs:
           ./gradlew :python:thin_wheel
     
       - uses: actions/upload-artifact@v3
+        # See https://github.com/actions/upload-artifact#readme
         with:
           name: wheel
           path: ./python/*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,7 +1,7 @@
 # This is a basic workflow to help you get started with Actions.
 # To be filled in as part of https://github.com/deshaw/pjrmi/pull/1
 
-name: CI
+name: Wheels
 
 # Controls when the workflow will run
 on:
@@ -14,10 +14,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build_wheel:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -26,12 +28,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      - name: build thin wheel
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          ./gradlew :python:thin_wheel
+    
+      - uses: actions/upload-artifact@3
+        with:
+          name: wheel
+          path: ./python/*.whl

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -102,6 +102,7 @@ task wheel() {
 
 task thin_wheel() {
     // Use pyproject.toml to build a pure-python wheel including the "*.jar" file
+    dependsOn copyArtifacts
     dependsOn genConfigFile
     doLast {
         exec {

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -84,6 +84,7 @@ task develop() {
 
 
 task wheel() {
+    // Use setuptools to build a wheel including the c-extension module
     dependsOn buildExt
     doLast {
         exec {
@@ -94,12 +95,13 @@ task wheel() {
                 project(":cpp").buildDir.absolutePath + "/lib/main/debug",
                 project(":java:jni").buildDir.absolutePath + "/libs/main/shared",
             ].join(":")
-            commandLine "python", "setup.py", "bdist_wheel"
+            commandLine "python3", "setup.py", "bdist_wheel"
         }
     }
 }
 
 task thin_wheel() {
+    // Use pyproject.toml to build a pure-python wheel including the "*.jar" file
     doLast {
         exec {
             environment "PJRMI_VERSION", pjrmiVersion

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -94,6 +94,19 @@ task wheel() {
                 project(":cpp").buildDir.absolutePath + "/lib/main/debug",
                 project(":java:jni").buildDir.absolutePath + "/libs/main/shared",
             ].join(":")
+            commandLine "python", "setup.py", "bdist_wheel"
+        }
+    }
+}
+
+task thin_wheel() {
+    doLast {
+        exec {
+            environment "PJRMI_VERSION", pjrmiVersion
+            environment "JAVA_HOME", System.properties['java.home']
+            environment "LIB_DIRS", [
+                project(":java:jni").buildDir.absolutePath + "/libs/main/shared",
+            ].join(":")
             commandLine "pip3", "wheel", "."
         }
     }

--- a/python/build.gradle
+++ b/python/build.gradle
@@ -102,6 +102,7 @@ task wheel() {
 
 task thin_wheel() {
     // Use pyproject.toml to build a pure-python wheel including the "*.jar" file
+    dependsOn genConfigFile
     doLast {
         exec {
             environment "PJRMI_VERSION", pjrmiVersion

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+    "pjrmi/*.py",
+  ]
+artifacts = [
+    "pjrmi/lib/*.jar",
+  ]
+
+[project]
+name = "pjrmi"
+
+# Using https://peps.python.org/pep-0639/
+# which is still in draft
+license = {text = "BSD-3-Clause"}
+description = "PJRmi, RMI between Python and Java"
+#authors = [{name = "D.E.Shaw"}]
+#maintainers = [
+#    {name = "D.E.Sahw", email="someone@deshaw.com"},
+#]
+requires-python = ">=3.6"
+readme = "README.md"
+classifiers = [
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: Science/Research',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: BSD License',
+    'Programming Language :: Java',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3 :: Only',
+    'Topic :: Software Development',
+    'Topic :: Scientific/Engineering',
+    'Operating System :: Microsoft :: Windows',
+    'Operating System :: POSIX',
+    'Operating System :: Unix',
+    'Operating System :: MacOS',
+]
+dynamic = ["version"]
+
+[project.urls]
+"Source code" = "https://github.com/deshaw/pjrmi"
+
+[tool.hatch.version]
+path = "pjrmi/_config.py"
+pattern = "PJRMI_VERSION = \"(?P<version>.+)\""
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Use hatch https://hatch.pypa.io/latest/ as a build backend to build a thin
-# (no c-extension) wheel. To change this to setuptools, comment out the
+# (no C-extension) wheel. To change this to setuptools, comment out the
 # build-backend line and add "setuptools", "wheel" to the required packages.
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@ artifacts = [ "pjrmi/lib/*.jar",
 [project]
 name = "pjrmi"
 dependencies = [
-    snappy
+    "snappy",
 ]
 
 # Using https://peps.python.org/pep-0639/ which is still in draft

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,7 +20,7 @@ license = {text = "BSD-3-Clause"}
 description = "PJRmi, RMI between Python and Java"
 authors = [{name = "D. E. Shaw & Co LP"}]
 maintainers = [
-    {"D. E. Shaw & Co LP", email="pjrmi@deshaw.com"},
+    {name="D. E. Shaw & Co LP", email="pjrmi@deshaw.com"},
 ]
 requires-python = ">=3.6"
 readme = "README.md"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,22 +5,20 @@ build-backend = "hatchling.build"
 [tool.hatch.build]
 include = [
     "pjrmi/*.py",
-  ]
-artifacts = [
-    "pjrmi/lib/*.jar",
-  ]
+]
+artifacts = [ "pjrmi/lib/*.jar",
+]
 
 [project]
 name = "pjrmi"
 
-# Using https://peps.python.org/pep-0639/
-# which is still in draft
+# Using https://peps.python.org/pep-0639/ which is still in draft
 license = {text = "BSD-3-Clause"}
 description = "PJRmi, RMI between Python and Java"
-#authors = [{name = "D.E.Shaw"}]
-#maintainers = [
-#    {name = "D.E.Sahw", email="someone@deshaw.com"},
-#]
+authors = [{name = "D. E. Shaw & Co LP"}]
+maintainers = [
+    {"D. E. Shaw & Co LP", email="pjrmi@deshaw.com"},
+]
 requires-python = ">=3.6"
 readme = "README.md"
 classifiers = [
@@ -30,7 +28,9 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Java',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,9 +14,13 @@ artifacts = [ "pjrmi/lib/*.jar",
 
 [project]
 name = "pjrmi"
+dependencies = [
+    snappy
+]
 
 # Using https://peps.python.org/pep-0639/ which is still in draft
 license = {text = "BSD-3-Clause"}
+
 description = "PJRmi, RMI between Python and Java"
 authors = [{name = "D. E. Shaw & Co LP"}]
 maintainers = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,4 +1,7 @@
 [build-system]
+# Use hatch https://hatch.pypa.io/latest/ as a build backend to build a thin
+# (no c-extension) wheel. To change this to setuptools, comment out the
+# build-backend line and add "setuptools", "wheel" to the required packages.
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Step one in uploading a wheel to PyPI for the project: create a version-and-platform-agnostic wheel that contains 
- `pjrmi/__init__.py`
- `pjrmi/_config.py
- `pjrmi/_util.py`
- `pjrmi/lib/pjrmi.jar`

This uses `gradlew :python:thin_wheel` to build the `jar`, and then the standards-compliant `pyproject.toml` to build the wheel via `hatchling`. The reviewers should take a look at the classifiers table to make sure it is accurate, I guessed some of the values

Steps two and three are 
- documentation to clearly state installing a JRE must be done outside of installing pjrme, 
- a github action to create the wheel as an artifact