### PR TITLE
Fix exception handling in PJRmiPipe::check_exception() function

### DIFF
--- a/python/extension/extension.cpp
+++ b/python/extension/extension.cpp
@@ -354,7 +354,7 @@ void PJRmiPipe::check_exception(const char* when)
 {
     if (_env->ExceptionCheck() == JNI_TRUE ) {
         jthrowable exceptionObj = _env->ExceptionOccurred();
-
+        _env->ExceptionClear();
         std::string errstr("[Unknown error]");
         jclass Throwable = _env->FindClass("java/lang/Throwable");
         if (Throwable != NULL) {


### PR DESCRIPTION
JVM is in an undefined state after an exception occurs, and most JNI functions will not operate correctly until the exception is cleared.