### PR TITLE
Add a dependabot configuration for keeping actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a dependabot configuration to keep github actions up to date. It will run a check once a week to automatically create a PR to update an action if an action has a new version available.

To enable this, you'll need to go into the Security -> Code Security settings for the repository and click the Enable button next to Dependabot version updates. This should also activate the Dependabot on Actions runners button as well.

![image](https://github.com/user-attachments/assets/8fc398a2-de9d-47c6-b181-a39a6c975d09)

See https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/ for context - we need to bump `upload-artifact` and `download-artifact` versions or they will stop working.
